### PR TITLE
deps: upgrade rand 0.8 → 0.10 across the workspace

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -12,6 +12,6 @@ petgraph-layout-omega = { path = "../layout/omega" }
 petgraph-layout-sgd = { path = "../layout/sgd" }
 petgraph-linalg-rdmds = { path = "../linalg/rdmds" }
 petgraph-quality-metrics = { path = "../quality-metrics" }
-rand = "0.8"
+rand = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/cli/src/bin/omega.rs
+++ b/crates/cli/src/bin/omega.rs
@@ -45,7 +45,7 @@ use petgraph_drawing::DrawingEuclidean2d;
 use petgraph_layout_omega::Omega;
 use petgraph_layout_sgd::{Scheduler, SchedulerExponential};
 use petgraph_linalg_rdmds::RdMds;
-use rand::thread_rng;
+use rand::rng;
 
 /// Command-line parameters for the Omega algorithm.
 #[derive(Debug)]
@@ -218,7 +218,7 @@ fn layout(
     drawing: &mut DrawingEuclidean2d<NodeIndex, f32>,
     params: &OmegaParams,
 ) {
-    let mut rng = thread_rng();
+    let mut rng = rng();
 
     // Create SGD instance using Omega builder pattern with command-line parameters
     let embedding = RdMds::new()

--- a/crates/cli/src/bin/sgd.rs
+++ b/crates/cli/src/bin/sgd.rs
@@ -15,7 +15,7 @@ use egraph_cli::{read_graph, write_graph};
 use petgraph::prelude::*;
 use petgraph_drawing::DrawingEuclidean2d;
 use petgraph_layout_sgd::{Scheduler, SchedulerExponential, SparseSgd};
-use rand::thread_rng;
+use rand::rng;
 
 /// Parses command-line arguments for input and output file paths.
 ///
@@ -49,7 +49,7 @@ fn layout(
     graph: &Graph<Option<()>, Option<()>, Undirected>,
     coordinates: &mut DrawingEuclidean2d<NodeIndex, f32>,
 ) {
-    let mut rng = thread_rng();
+    let mut rng = rng();
     let mut sgd = SparseSgd::new().h(200).build(graph, |_| 30., &mut rng);
     let mut scheduler = sgd.scheduler::<SchedulerExponential<f32>>(1000, 0.1);
     scheduler.run(&mut |eta| {

--- a/crates/clustering/Cargo.toml
+++ b/crates/clustering/Cargo.toml
@@ -8,6 +8,6 @@ petgraph = "0.6"
 petgraph-linalg-rdmds = { path = "../linalg/rdmds" }
 petgraph-drawing = { path = "../drawing" }
 ndarray = "0.16"
-rand = "0.8"
+rand = "0.10"
 linfa = "0.8"
 linfa-clustering = "0.8"

--- a/crates/clustering/src/algorithms/label_propagation.rs
+++ b/crates/clustering/src/algorithms/label_propagation.rs
@@ -1,6 +1,6 @@
 use crate::{CommunityDetection, utils::renumber_communities};
 use petgraph::visit::{EdgeCount, IntoNeighbors, IntoNodeIdentifiers};
-use rand::{SeedableRng, rngs::StdRng, seq::SliceRandom};
+use rand::{SeedableRng, rngs::StdRng, seq::IndexedRandom, seq::SliceRandom};
 use std::collections::HashMap;
 use std::hash::Hash;
 
@@ -101,7 +101,7 @@ where
         // Create a Random Number Generator with seed if provided
         let mut rng = match self.seed {
             Some(seed) => StdRng::seed_from_u64(seed),
-            None => StdRng::from_entropy(),
+            None => StdRng::from_rng(&mut rand::rng()),
         };
 
         // Store all nodes in a vector for random shuffling

--- a/crates/layout/kernel-sgd/Cargo.toml
+++ b/crates/layout/kernel-sgd/Cargo.toml
@@ -14,4 +14,4 @@ petgraph = "0.6"
 petgraph-drawing = { path = "../../drawing" }
 petgraph-layout-sgd = { path = "../sgd" }
 petgraph-linalg-spmv = { path = "../../linalg/spmv" }
-rand = "0.8"
+rand = "0.10"

--- a/crates/layout/kernel-sgd/src/hutchinson.rs
+++ b/crates/layout/kernel-sgd/src/hutchinson.rs
@@ -5,7 +5,7 @@
 
 use ndarray::Array2;
 use num_traits::Float;
-use rand::Rng;
+use rand::{Rng, RngExt};
 
 /// Hutchinson estimator for querying kernel matrix elements.
 ///
@@ -125,7 +125,7 @@ where
     R: Rng,
 {
     Array2::from_shape_fn((n, num_vectors), |_| {
-        if rng.gen::<bool>() {
+        if rng.random::<bool>() {
             T::one()
         } else {
             -T::one()

--- a/crates/layout/kernel-sgd/src/kernel_sgd.rs
+++ b/crates/layout/kernel-sgd/src/kernel_sgd.rs
@@ -4,7 +4,7 @@ use crate::diffusion_kernel::DiffusionKernel;
 use petgraph::visit::{EdgeRef, IntoEdges, IntoNodeIdentifiers, NodeCount, NodeIndexable};
 use petgraph_drawing::{DrawingIndex, DrawingValue};
 use petgraph_layout_sgd::Sgd;
-use rand::Rng;
+use rand::{Rng, RngExt};
 use std::collections::HashSet;
 
 /// KernelSgd builder for creating SGD instances from diffusion kernel distances.
@@ -215,7 +215,7 @@ where
     // Step 2: Add random node pairs with kernel distances
     for i in 0..n {
         for _ in 0..k {
-            let j = rng.gen_range(0..n);
+            let j = rng.random_range(0..n);
             if i != j {
                 let pair_key = if i < j { (i, j) } else { (j, i) };
 

--- a/crates/layout/kernel-sgd/src/power_method.rs
+++ b/crates/layout/kernel-sgd/src/power_method.rs
@@ -3,7 +3,7 @@
 use ndarray::Array1;
 use num_traits::Float;
 use petgraph_linalg_spmv::SparseSymmetricMatrix;
-use rand::Rng;
+use rand::{Rng, RngExt};
 
 /// Estimates the maximum eigenvalue of a symmetric matrix using the power method.
 ///
@@ -31,7 +31,7 @@ where
     let n = matrix.dim();
 
     // Initialize with random vector
-    let mut v = Array1::from_shape_fn(n, |_| T::from(rng.gen_range(-1.0..1.0)).unwrap());
+    let mut v = Array1::from_shape_fn(n, |_| T::from(rng.random_range(-1.0..1.0)).unwrap());
 
     // Normalize
     let norm = v.iter().map(|&x| x * x).sum::<T>().sqrt();

--- a/crates/layout/omega/Cargo.toml
+++ b/crates/layout/omega/Cargo.toml
@@ -8,7 +8,7 @@ ndarray = "0.16"
 petgraph = "0.6"
 petgraph-drawing = { path = "../../drawing" }
 petgraph-layout-sgd = { path = "../sgd" }
-rand = "0.8"
+rand = "0.10"
 
 [dev-dependencies]
 petgraph-linalg-rdmds = { path = "../../linalg/rdmds" }

--- a/crates/layout/omega/src/lib.rs
+++ b/crates/layout/omega/src/lib.rs
@@ -18,7 +18,7 @@
 //! use petgraph_layout_omega::Omega;
 //! use petgraph_layout_sgd::{Scheduler, SchedulerExponential};
 //! use petgraph_drawing::DrawingEuclidean2d;
-//! use rand::thread_rng;
+//! use rand::rng;
 //!
 //! // Create a graph
 //! let mut graph = Graph::new_undirected();
@@ -30,7 +30,7 @@
 //! graph.add_edge(c, a, ());
 //!
 //! // Step 1: Compute spectral embedding with RdMds
-//! let mut rng = thread_rng();
+//! let mut rng = rng();
 //! let rdmds = RdMds::new().d(2).shift(1e-3f32);
 //! let embedding = rdmds.embedding(&graph, |_| 1.0f32, &mut rng);
 //!
@@ -64,7 +64,7 @@ mod tests {
     use super::*;
     use petgraph::Graph;
     use petgraph_linalg_rdmds::RdMds;
-    use rand::thread_rng;
+    use rand::rng;
 
     #[test]
     fn test_omega_basic_functionality() {
@@ -78,7 +78,7 @@ mod tests {
         graph.add_edge(c, a, ());
 
         // Compute embedding with RdMds
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let mut rdmds = RdMds::new();
         let embedding = rdmds
             .d(2)
@@ -123,7 +123,7 @@ mod tests {
         graph.add_edge(a, b, ());
 
         // Compute embedding with RdMds
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let mut rdmds = RdMds::new();
         let embedding = rdmds
             .d(2)

--- a/crates/layout/omega/src/omega.rs
+++ b/crates/layout/omega/src/omega.rs
@@ -4,7 +4,7 @@ use ndarray::{Array2, Zip};
 use petgraph::visit::{EdgeRef, IntoEdges, IntoNodeIdentifiers, NodeCount, NodeIndexable};
 use petgraph_drawing::{DrawingIndex, DrawingValue};
 use petgraph_layout_sgd::Sgd;
-use rand::Rng;
+use rand::{Rng, RngExt};
 use std::collections::{HashMap, HashSet};
 
 /// Omega builder for creating SGD instances from spectral embeddings.
@@ -135,7 +135,7 @@ where
     // Step 2: Add random node pairs with Euclidean distances (avoiding duplicates)
     for i in 0..n {
         for _ in 0..k {
-            let j = rng.gen_range(0..n);
+            let j = rng.random_range(0..n);
             if i != j {
                 let pair_key = if i < j { (i, j) } else { (j, i) };
 

--- a/crates/layout/separation-constraints/Cargo.toml
+++ b/crates/layout/separation-constraints/Cargo.toml
@@ -20,7 +20,7 @@ petgraph-layout-sgd = { path = "../sgd" }
 plotters = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-rand = "0.8"
+rand = "0.10"
 
 [[example]]
 name = "qh882_separation_constraints"

--- a/crates/layout/separation-constraints/examples/dependency_graph_layered.rs
+++ b/crates/layout/separation-constraints/examples/dependency_graph_layered.rs
@@ -4,7 +4,7 @@ use petgraph_layout_mds::ClassicalMds;
 use petgraph_layout_separation_constraints::project_rectangle_no_overlap_constraints_2d;
 use petgraph_layout_sgd::{FullSgd, Scheduler, SchedulerExponential};
 use plotters::prelude::*;
-use rand::thread_rng;
+use rand::rng;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::error::Error;
@@ -134,7 +134,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let iterations = 100;
     let mut sgd = FullSgd::new().build(&undirected_graph, |_| edge_length);
     let mut scheduler = sgd.scheduler::<SchedulerExponential<f32>>(iterations, 0.1);
-    let mut rng = thread_rng();
+    let mut rng = rng();
 
     // Optimize layout using stress-majorization and constraints
     println!("Optimizing layout with constraints...");

--- a/crates/layout/separation-constraints/examples/lesmis_cluster_overlap.rs
+++ b/crates/layout/separation-constraints/examples/lesmis_cluster_overlap.rs
@@ -9,7 +9,7 @@ use petgraph_layout_separation_constraints::{
 use petgraph_layout_sgd::{FullSgd, Scheduler, SchedulerExponential};
 use plotters::prelude::*;
 use plotters::style::RGBColor;
-use rand::thread_rng;
+use rand::rng;
 use std::collections::HashMap;
 use std::error::Error;
 use std::f32;
@@ -52,7 +52,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut drawing = mds.run_2d();
     let mut sgd = FullSgd::new().build(&graph, |_| edge_length);
     let mut scheduler = sgd.scheduler::<SchedulerExponential<f32>>(iterations, 0.1);
-    let mut rng = thread_rng();
+    let mut rng = rng();
 
     scheduler.run(&mut |eta| {
         sgd.shuffle(&mut rng);

--- a/crates/layout/sgd/Cargo.toml
+++ b/crates/layout/sgd/Cargo.toml
@@ -9,4 +9,4 @@ ordered-float = "3.0"
 petgraph = "0.6"
 petgraph-algorithm-shortest-path = { path = "../../algorithm/shortest-path" }
 petgraph-drawing = { path = "../../drawing" }
-rand = "0.8"
+rand = "0.10"

--- a/crates/layout/sgd/src/sparse_sgd.rs
+++ b/crates/layout/sgd/src/sparse_sgd.rs
@@ -255,7 +255,7 @@ where
     let mut length = length;
     let n = indices.len();
     let mut pivot = vec![];
-    pivot.push(nodes[rng.gen_range(0..n)]);
+    pivot.push(nodes[rng.random_range(0..n)]);
     let mut distance_matrix = SubDistanceMatrix::empty(graph);
     distance_matrix.push(pivot[0]);
     dijkstra_with_distance_matrix(graph, &mut length, pivot[0], &mut distance_matrix);
@@ -300,7 +300,7 @@ where
     if s == 0. {
         panic!("could not choice pivot");
     }
-    let x = rng.gen_range(0.0..s);
+    let x = rng.random_range(0.0..s);
     s = 0.;
     for i in 0..n {
         s += values[i].to_f32().unwrap();

--- a/crates/linalg/rdmds/Cargo.toml
+++ b/crates/linalg/rdmds/Cargo.toml
@@ -8,4 +8,4 @@ ndarray = "0.16"
 num-traits = "0.2"
 petgraph = "0.6"
 petgraph-drawing = { path = "../../drawing" }
-rand = "0.8"
+rand = "0.10"

--- a/crates/linalg/rdmds/src/eigenvalue.rs
+++ b/crates/linalg/rdmds/src/eigenvalue.rs
@@ -5,7 +5,7 @@
 use ndarray::{Array1, Array2, ArrayView2, s};
 use petgraph::visit::{EdgeRef, IntoEdges, IntoNodeIdentifiers, NodeCount, NodeIndexable};
 use petgraph_drawing::{DrawingIndex, DrawingValue};
-use rand::Rng;
+use rand::{Rng, RngExt};
 use std::collections::HashMap;
 
 /// IC(0) Incomplete Cholesky preconditioner for sparse symmetric positive definite matrices.
@@ -305,7 +305,7 @@ where
     S: DrawingValue,
     R: Rng,
 {
-    Array1::from_shape_fn(n, |_| S::from_f32(rng.gen_range(-1.0..1.0)).unwrap())
+    Array1::from_shape_fn(n, |_| S::from_f32(rng.random_range(-1.0..1.0)).unwrap())
 }
 
 /// Performs Gram-Schmidt orthogonalization of a vector against known vectors.

--- a/crates/linalg/rdmds/src/lib.rs
+++ b/crates/linalg/rdmds/src/lib.rs
@@ -12,7 +12,7 @@
 //! ```rust
 //! use petgraph::Graph;
 //! use petgraph_linalg_rdmds::RdMds;
-//! use rand::thread_rng;
+//! use rand::rng;
 //!
 //! // Create a graph
 //! let mut graph = Graph::new_undirected();
@@ -24,7 +24,7 @@
 //! graph.add_edge(c, a, ());
 //!
 //! // Compute spectral embedding
-//! let mut rng = thread_rng();
+//! let mut rng = rng();
 //! let embedding = RdMds::new()
 //!     .d(2)
 //!     .shift(1e-3f32)

--- a/crates/python/Cargo.toml
+++ b/crates/python/Cargo.toml
@@ -28,4 +28,4 @@ petgraph-layout-stress-majorization = { path = "../layout/stress-majorization" }
 petgraph-layout-separation-constraints = { path = "../layout/separation-constraints" }
 petgraph-linalg-rdmds = { path = "../linalg/rdmds" }
 petgraph-quality-metrics = { path = "../quality-metrics" }
-rand = "0.8"
+rand = "0.10"

--- a/crates/python/src/rng.rs
+++ b/crates/python/src/rng.rs
@@ -48,7 +48,7 @@ impl PyRng {
     #[new]
     fn new() -> PyRng {
         PyRng {
-            rng: StdRng::from_entropy(),
+            rng: StdRng::from_rng(&mut rand::rng()),
         }
     }
 

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -12,7 +12,14 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 console_error_panic_hook = "0.1"
-getrandom = { version = "0.2", features = ["js"] }
+# This crate's rand 0.10 pulls getrandom 0.4, whose `wasm_js` feature alone
+# selects the browser backend for wasm32 (no `getrandom_backend` cfg needed,
+# unlike getrandom 0.3). linfa (via petgraph-clustering / petgraph-quality-
+# metrics) is still on rand 0.8 and pulls getrandom 0.2 transitively, which
+# separately needs the `js` feature to compile for wasm32. Both are required
+# until linfa upgrades off rand 0.8.
+getrandom = { version = "0.4", features = ["wasm_js"] }
+getrandom_legacy = { package = "getrandom", version = "0.2", features = ["js"] }
 js-sys = "0.3"
 ndarray = "0.16"
 petgraph = "0.6"
@@ -26,7 +33,7 @@ petgraph-layout-overwrap-removal = { path = "../layout/overwrap-removal" }
 petgraph-layout-sgd = { path = "../layout/sgd" }
 petgraph-layout-stress-majorization = { path = "../layout/stress-majorization" }
 petgraph-quality-metrics = { path = "../quality-metrics" }
-rand = "0.8"
+rand = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.4"
 wasm-bindgen = "0.2"

--- a/crates/wasm/src/rng.rs
+++ b/crates/wasm/src/rng.rs
@@ -40,7 +40,7 @@ impl JsRng {
     #[wasm_bindgen(constructor)]
     pub fn new() -> JsRng {
         JsRng {
-            rng: StdRng::from_entropy(),
+            rng: StdRng::from_rng(&mut rand::rng()),
         }
     }
 


### PR DESCRIPTION
Bumps `rand` from 0.8 to **0.10** across all crates that depend on it, migrating the breaking API changes from both the 0.9 and 0.10 majors.

## API migration
- `thread_rng()` → `rng()`
- `Rng::gen()` / `gen_range()` → `random()` / `random_range()` (renamed in 0.9)
- **0.10 split the convenience methods into a new `RngExt` trait** — files that call `random()` / `random_range()` now import `rand::RngExt` alongside `rand::Rng` (the latter is the former `RngCore`). `RngExt` is blanket-implemented over `R: Rng`, so generic bounds are unchanged.
- `SeedableRng::from_entropy()` → `from_os_rng()` (0.9) → **removed in 0.10**; replaced with `from_rng(&mut rand::rng())` (the seeding path rand 0.10 itself recommends).
- `seq::SliceRandom::choose` moved to `seq::IndexedRandom` (0.9); `label_propagation` imports both traits.

## wasm / getrandom
rand 0.10 pulls **getrandom 0.4**, whose `wasm_js` feature **alone** selects the browser backend for `wasm32-unknown-unknown` — no `getrandom_backend` cfg flag is required (getrandom 0.3 needed one). The temporary `crates/wasm/.cargo/config.toml` added for getrandom 0.3 is therefore removed.

**linfa** (transitive via `petgraph-clustering` / `petgraph-quality-metrics`) is still on rand 0.8 → **getrandom 0.2**, which still needs the `js` feature, so both getrandom majors are declared as direct deps in the wasm crate until linfa upgrades. The `wasm32-unknown-unknown` build compiles both getrandom backends cleanly.

## Testing
- `cargo test` passes for all rand-affected crates (sgd, omega, kernel-sgd, rdmds, clustering).
- `cargo check -p egraph-python` is clean.
- Pre-existing failures on `master`, unrelated to this change and unchanged by it: `clustering::infomap::test_infomap_simple_graph` (doesn't use rand) and `clustering::label_propagation::test_label_propagation_reproducibility` (flaky on the baseline — 5/8 runs fail on unchanged code due to `HashMap` iteration-order nondeterminism in tie-breaking, independent of rand version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)